### PR TITLE
Fix compil error when option "WITH_CURL" is OFF

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -56,7 +56,7 @@
 #include <windows.h>
 #endif
 
-#ifdef WITH_OAUTHBEARER_OIDC
+#if WITH_OAUTHBEARER_OIDC
 #include <curl/curl.h>
 #endif
 


### PR DESCRIPTION
Update rdkafka_conf.c
Don't include header curl file